### PR TITLE
在数据导入类中添加对数据的拆分导入，以实现数据并行，拆分按照进程编号进行

### DIFF
--- a/logistic_regression/include/load_data.h
+++ b/logistic_regression/include/load_data.h
@@ -13,11 +13,12 @@ class Load_Data {
 public:
     Load_Data();
     ~Load_Data();
-    void load_data(const char *train_file, std::string split_tag, int rank, int nproc);
+    void load_data(const char *train_file, std::string split_tag, int rank, int nproc, long int glo_samp_num);
     std::vector<std::vector<sparse_feature> > fea_matrix;
     std::vector<double> label;
     long int loc_fea_dim = 0;
     long int glo_fea_dim = 0;
+    long int loc_samp_num = 0;
 
 private:
     void split_line(const std::string& line, const std::string& split_tag, std::vector<std::string>& feature_index);

--- a/logistic_regression/src/lr_main.cpp
+++ b/logistic_regression/src/lr_main.cpp
@@ -13,10 +13,26 @@ int main(int argc,char* argv[]){
     std::cout<<"my process rank: "<<rank<<", totoal process num: "<<nproc<<std::endl;
     const char *train_data_file = argv[1];
     const char *test_data_file = argv[2];
+
+    long int glo_samp_num = 0;
+    if(0 == rank) {
+        std::ifstream tfin(train_data_file, std::ios::in);
+        if(!tfin) std::cerr << "process "<< rank << " open error get feature number..." << train_data_file << std::endl;
+        std::string line;
+        while(getline(tfin, line)) {
+                glo_samp_num++;
+        }
+        tfin.close();
+    }
+    MPI_Bcast(&glo_samp_num, 1, MPI_LONG, 0, MPI_COMM_WORLD);
+    std::cout<< "process "<< rank <<", global sample number: "<<glo_samp_num<<std::endl;
+
     std::string split_tag = " ";
     Load_Data ld; 
-    ld.load_data(train_data_file, split_tag, rank, nproc);
+    ld.load_data(train_data_file, split_tag, rank, nproc, glo_samp_num);
     std::cout<< "process "<< rank <<", local feature dimension: "<<ld.loc_fea_dim<<std::endl;
+    std::cout<< "process "<< rank <<", local sample number: "<<ld.loc_samp_num<<std::endl;
+    std::cout<< "process "<< rank <<", local sample number by matrix: "<<ld.fea_matrix.size()<<std::endl;
     LR lr(&ld, nproc, rank);
     //lr.run();
     MPI::Finalize();


### PR DESCRIPTION
*  在导入数据类中添加对数据的拆分导入，以实现数据并行，拆分按照进行编号进行
*  定义了零时变量other_loc_fea_dim来接收主进程之外的进程传递来的loc_fea_dim，避免覆盖主进程的loc_fea_dim